### PR TITLE
Release Beta v2.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.0-beta.3
+- [FIX] Fixed an issue caused by twitch sending numbers as strings in the `message` event.
+  - This fix is made especially for the `bits` field of the `message` event.
+
 ## v2.0.0-beta.2
 - [NEW] We now expose the tags field of the message on the `message` event, this field contains all the tags of the message sent by the user. This includes badges, color, first message, returning chatter, etc.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twitchapis/twitch.js",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@twitchapis/twitch.js",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@discordjs/collection": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twitchapis/twitch.js",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "Twitch.JS is a Nodejs library made with typescript to interact with the Twitch API in a simple and easy way.",
   "keywords": [
     "nodejs",

--- a/src/utils/messageParser.ts
+++ b/src/utils/messageParser.ts
@@ -174,7 +174,7 @@ export function parseFinalMessage(client: Client, message: ITwitchMessage): IMes
     content: message.parameters,
     id,
     tags: message.tags,
-    bits: message.tags.bits ?? 0,
+    bits: parseInt(message.tags.bits) ?? 0,
     channel,
     reply: (message: string): Promise<void> => {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
- [FIX] Fixed an issue caused by twitch sending numbers as strings in the `message` event.
  - This fix is made especially for the `bits` field of the `message` event.